### PR TITLE
guix: pin python-monklib to MONK-library v0.1.0

### DIFF
--- a/guix/monk/packages.scm
+++ b/guix/monk/packages.scm
@@ -28,13 +28,13 @@
 (define-public python-monklib
   (package
     (name "python-monklib")
-    (version "0.2.4")
+    (version "0.1.0")
     (source
      (origin
        (method git-fetch)
        (uri (git-reference
              (url "https://github.com/OUH-MESHLab/MONK-library.git")
-             (commit "e4885c10f4e34c9c5575123cf48afe2882357eed")))
+             (commit "90d484d6e0de0a96e30637476dd82772574369c0")))
        (file-name (git-file-name name version))
        (sha256
         (base32 "1hl26clc845jyzalffhahwzchw5x5ai817i65pshv11pjdm50168"))))


### PR DESCRIPTION
## Summary
- Bump `python-monklib` channel pin to MONK-library v0.1.0 (`90d484d6e0de`).
- Version field follows the upstream release tag (`0.2.4` → `0.1.0`).
- Source content is identical to the previous pre-rebase commit, so the `sha256` hash is unchanged.

## Test plan
- [x] `guix time-machine -C channels-lock.scm -- system build -L lib lib/machines/monk.scm` from `ivs-infrastructure` resolves and builds against the new pin.